### PR TITLE
fix: :pencil2: Fixes "case sensetive" to "case sensitive" in the comments.

### DIFF
--- a/src/glevenshtein.gleam
+++ b/src/glevenshtein.gleam
@@ -6,7 +6,7 @@ import gleam/result
 import gleam/string
 
 /// This function calculates the levenshtein distance.
-/// It isn't case sensetive
+/// It isn't case sensitive
 /// 
 /// ## Examples
 /// 


### PR DESCRIPTION
Hi, here is a pull request that fixes a typo ("sensetive" -> "sensitive")